### PR TITLE
feat: use yaml instead of json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@jsr:registry=https://npm.jsr.io

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "@biomejs/biome": "^1.9.4",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@mozilla/readability": "^0.5.0",
+        "@std/yaml": "npm:@jsr/std__yaml",
         "@types/bun": "^1.1.15",
         "@types/micromatch": "^4.0.9",
         "@types/turndown": "^5.0.5",
@@ -201,6 +202,8 @@
     "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.39.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-6w9uMuza+LbLCVoNKL5FSLE7yvYkq9laSd09bwS0tMjkwXrmib/4KmoJcrKhLWHvw19mwU+33ndC69T7weNNjQ=="],
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.39.0", "", { "os": "win32", "cpu": "x64" }, "sha512-yAkUOkIKZlK5dl7u6dg897doBgLXmUHhIINM2c+sND3DZwnrdQkkSiDh7N75Ll4mM4dxSkYfXqU9fW3lLkMFug=="],
+
+    "@std/yaml": ["@jsr/std__yaml@1.0.5", "https://npm.jsr.io/~/11/@jsr/std__yaml/1.0.5.tgz", {}, "sha512-jbh2xwnja+ar+7NE0oDTlbST1WW29dAQOKX8+1DZgdT54NVt9lZ9YVDrzh4uP1w6ZHVirtY0z99BSym0v+Zh4Q=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.9.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw=="],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"@biomejs/biome": "^1.9.4",
 		"@modelcontextprotocol/sdk": "^1.9.0",
 		"@mozilla/readability": "^0.5.0",
+		"@std/yaml": "npm:@jsr/std__yaml",
 		"@types/bun": "^1.1.15",
 		"@types/micromatch": "^4.0.9",
 		"@types/turndown": "^5.0.5",

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { stringify } from "@std/yaml";
 import { version } from "../package.json";
 import { fetchSite } from "./fetch-site.ts";
 import { logger } from "./logger.ts";
@@ -101,7 +102,7 @@ export async function startServer(
 					content: [
 						{
 							type: "text",
-							text: page.content,
+							text: stringify(page),
 						},
 					],
 				};


### PR DESCRIPTION
This pull request includes several changes to the project configuration and codebase to integrate and utilize the `@std/yaml` package. The most important changes involve updating the package registry and dependencies, as well as modifying the server code to use the new YAML stringification functionality.

Configuration updates:

* [`.npmrc`](diffhunk://#diff-e813096d69c49812e40e00be9ac8fa14d77f0ec1f97ab4c45cb096b3bedd35deR1): Added a new registry URL for the `@jsr` scope.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R32): Added the `@std/yaml` package to the dependencies list.

Code updates:

* [`src/server.ts`](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R5): Imported the `stringify` function from the `@std/yaml` package.
* [`src/server.ts`](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595L104-R105): Updated the `startServer` function to use `stringify` for converting page content to YAML format.