### PR TITLE
fix: cache option

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -32,7 +32,7 @@ export async function startServer(
 		match,
 		contentSelector,
 		limit,
-		cache,
+		cache = false,
 	} = options;
 
 	// create server instance

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,7 @@ interface StartServerOptions {
 	match?: string | string[];
 	contentSelector?: string;
 	limit?: number;
-	noCache?: boolean;
+	cache?: boolean;
 	silent?: boolean;
 }
 
@@ -32,7 +32,7 @@ export async function startServer(
 		match,
 		contentSelector,
 		limit,
-		noCache = false,
+		cache,
 	} = options;
 
 	// create server instance
@@ -50,7 +50,7 @@ export async function startServer(
 
 	let pages: FetchSiteResult | undefined = undefined;
 
-	if (!noCache) {
+	if (cache) {
 		// check if cache exists
 		if (fs.existsSync(cacheFile)) {
 			logger.info("Using cache file", cacheFile);
@@ -78,7 +78,7 @@ export async function startServer(
 		return server;
 	}
 
-	if (!noCache) {
+	if (cache) {
 		// create cache dir if not exists
 		if (!fs.existsSync(catchDir)) {
 			fs.promises.mkdir(catchDir, { recursive: true });


### PR DESCRIPTION
Fixed the issue where the `--no-cache` option wasn't working.
In cac, `--no-cache` sets `cache` to `false`, and otherwise, `cache` is set to `true`.