### PR TITLE
feat: introducing Tool Name Strategy option (fixes: #6)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ jobs:
           bun-version: latest
       - run: bun install --frozen-lockfile
       - run: bun lint
+      - run: bun test
 
   npm-publish-dry-run-and-upload-pkg-pr-now:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ sitemcp https://daisyui.com
 sitemcp https://daisyui.com --concurrency 10
 ```
 
+### Tool Name Strategy
+
+Use `-t, --tool-name-strategy` to specify the tool name strategy, it will be used as the MCP server name (default: `domain`):
+This will be used as the MCP server name.
+
+```bash
+sitemcp https://vite.dev -t domain # indexOfVite / getDocumentOfVite
+sitemcp https://react-tweet.vercel.app/ -t subdomain # indexOfReactTweet / getDocumentOfReactTweet
+sitemcp https://ryoppippi.github.io/vite-plugin-favicons/ -t pathname # indexOfVitePluginFavicons / getDocumentOfVitePluginFavicons
+```
+
 ### Match specific pages
 
 Use the `-m, --match` flag to specify the pages you want to fetch:

--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "@types/turndown": "^5.0.5",
         "bumpp": "^10.1.0",
         "cac": "^6.7.14",
+        "just-pascal-case": "^3.2.0",
         "lint-staged": "^15.5.0",
         "p-queue": "^8.0.1",
         "picocolors": "^1.1.1",
@@ -419,6 +420,8 @@
     "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
+
+    "just-pascal-case": ["just-pascal-case@3.2.0", "", {}, "sha512-B0PW5mgJrsGmXdvDLxC2Kdfyie74m+mRO+iCjJ+Es0Jl5kcQwVfB0qb/qiDOCE3m0XUOo1SdZBWzUlNCO9zreg=="],
 
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"prepack": "bun run build",
 		"lint": "biome check .",
 		"format": "biome check --write .",
+		"test": "bun test",
 		"typecheck": "tsc --noEmit",
 		"prepare": "simple-git-hooks"
 	},
@@ -36,6 +37,7 @@
 		"@types/turndown": "^5.0.5",
 		"bumpp": "^10.1.0",
 		"cac": "^6.7.14",
+		"just-pascal-case": "^3.2.0",
 		"lint-staged": "^15.5.0",
 		"p-queue": "^8.0.1",
 		"picocolors": "^1.1.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,10 @@ cli
 	.option("--limit <limit>", "Limit the result to this amount of pages")
 	.option("--silent", "Do not print any logs")
 	.option("--no-cache", "Do not use cache")
+	.option(
+		"-t, --tool-name-strategy <strategy>",
+		"Tool name strategy ('subdomain' | 'domain' | 'pathname') default: 'domain'",
+	)
 	.action(async (url, flags) => {
 		if (!url) {
 			cli.outputHelp();

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,3 +33,5 @@ export type Page = {
 };
 
 export type FetchSiteResult = Map<string, Page>;
+
+export type ToolNameStrategy = "subdomain" | "domain" | "pathname";

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+
+import { getDomain, getPathname, getSubdomain } from "./utils";
+
+test("getSubdomain", () => {
+	expect(getSubdomain("https://feature-sliced.github.io/documentation/")).toBe(
+		"feature-sliced",
+	);
+	expect(getSubdomain("https://github.io/documentation/")).toBeUndefined();
+});
+
+test("getDomain", () => {
+	expect(getDomain("https://feature-sliced.github.io/documentation/")).toBe(
+		"github",
+	);
+	expect(getDomain("https://github.io/documentation/")).toBe("github");
+});
+
+test("getPathname", () => {
+	expect(getPathname("https://feature-sliced.github.io/documentation/")).toBe(
+		"documentation",
+	);
+	expect(getPathname("https://github.io/documentation/")).toBe("documentation");
+});

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,6 +1,11 @@
 import { expect, test } from "bun:test";
 
-import { getDomain, getPathname, getSubdomain } from "./utils";
+import {
+	getDomain,
+	getPathname,
+	getSubdomain,
+	sanitizeToolName,
+} from "./utils";
 
 test("getSubdomain", () => {
 	expect(getSubdomain("https://feature-sliced.github.io/documentation/")).toBe(
@@ -21,4 +26,25 @@ test("getPathname", () => {
 		"documentation",
 	);
 	expect(getPathname("https://github.io/documentation/")).toBe("documentation");
+});
+
+test("sanitizeToolName", () => {
+	expect(
+		sanitizeToolName(
+			"https://feature-sliced.github.io/documentation/",
+			"subdomain",
+		),
+	).toBe("FeatureSliced");
+	expect(
+		sanitizeToolName(
+			"https://feature-sliced.github.io/documentation/",
+			"domain",
+		),
+	).toBe("Github");
+	expect(
+		sanitizeToolName(
+			"https://feature-sliced.github.io/documentation/",
+			"pathname",
+		),
+	).toBe("Documentation");
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import * as os from "node:os";
 import * as path from "node:path";
 import * as process from "node:process";
+import pascalCase from "just-pascal-case";
 import micromatch from "micromatch";
 import * as ufo from "ufo";
 
@@ -45,10 +46,37 @@ export function sanitizeUrl(url: string): string {
 	);
 }
 
-export function sanitizeToolName(name: string): string {
-	// Remove common URL prefixes and invalid characters
-	return `getDocumentOf-${name}`
-		.replace(/^https?:\/\//, "") // Remove http:// or https://
-		.replace(/[^a-zA-Z0-9_-]/g, "_") // Replace invalid chars with underscore
-		.substring(0, 64); // Limit to 64 characters
+/**
+ * get subdomain from url
+ * @example
+ * - https://feature-sliced.github.io/documentation/ => feature-sliced
+ */
+export function getSubdomain(url: string): string | undefined {
+	const { hostname } = new URL(url);
+	const parts = hostname.split(".");
+	if (parts.length > 2) {
+		return parts[0];
+	}
+	return undefined;
+}
+
+/**
+ * get domain without subdomain and tld
+ * @example
+ * - https://feature-sliced.github.io/documentation/ => github
+ */
+export function getDomain(url: string): string | undefined {
+	const { hostname } = new URL(url);
+	const [tld, ...parts] = hostname.split(".").reverse();
+	return parts.reverse().at(-1);
+}
+
+/**
+ * get pathname from url
+ * @example
+ * - https://feature-sliced.github.io/documentation/ => documentation
+ */
+export function getPathname(url: string): string | undefined {
+	const { pathname } = new URL(url);
+	return pathname.replaceAll("/", "-").replace(/-/g, " ").trim();
 }


### PR DESCRIPTION
I tested with the config below:
```json
{
  "mcpServers": {
    "FSD": {
      "command": "/Users/username/.nodenv/shims/npx",  // Using path to npx because of nodenv
      "args": [
        "-y",
        "https://pkg.pr.new/ryoppippi/sitemcp@5937251",
        "https://feature-sliced.github.io/documentation/",
        "-t",
       "subdomain"
      ],
      "logLevel": "warn"
    }
  }
}
```

and it works!!

<img width="872" alt="SCR-20250409-rwaj" src="https://github.com/user-attachments/assets/f01369b3-e82c-40dd-adef-1d8a974b468e" />


This pull request introduces several new features and improvements across multiple files, primarily focusing on adding a tool name strategy option and enhancing test coverage. The most important changes include adding the `tool-name-strategy` option, updating related server and utility functions, and expanding the test suite.

### New Features:
* [`src/cli.ts`](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddR17-R20): Added a new command-line option `-t, --tool-name-strategy` to specify the tool name strategy. (`[src/cli.tsR17-R20](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddR17-R20)`)
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R45-R55): Documented the new `-t, --tool-name-strategy` option with examples. (`[README.mdR45-R55](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R45-R55)`)

### Server and Utility Function Updates:
* [`src/server.ts`](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R26): Updated the `startServer` function to accept and handle the `toolNameStrategy` option, defaulting to "domain". (`[[1]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R26)`, `[[2]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R39)`, `[[3]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595L94-R99)`)
* [`src/types.ts`](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR36-R37): Added a new type `ToolNameStrategy` to define the possible values for the tool name strategy. (`[src/types.tsR36-R37](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR36-R37)`)
* [`src/utils.ts`](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351L48-R120): Refactored the `sanitizeToolName` function to use the new strategy types and added helper functions `getSubdomain`, `getDomain`, and `getPathname`. (`[src/utils.tsL48-R120](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351L48-R120)`)

### Test Coverage:
* [`src/utils.test.ts`](diffhunk://#diff-04abd0e283864d1e858d70a5f86f67ccf45fcd3b752e56b136c3eee449b06b28R1-R50): Added tests for the new utility functions and the updated `sanitizeToolName` function to ensure proper functionality. (`[src/utils.test.tsR1-R50](diffhunk://#diff-04abd0e283864d1e858d70a5f86f67ccf45fcd3b752e56b136c3eee449b06b28R1-R50)`)

### Additional Changes:
* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR18): Added a step to run tests in the CI workflow. (`[.github/workflows/ci.yamlR18](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR18)`)
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R15): Added a new script for running tests and included the `just-pascal-case` dependency. (`[[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R15)`, `[[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R40)`)