### PR TITLE
Add max_length configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,20 +40,26 @@ sitemcp https://daisyui.com
 
 # or better concurrency
 sitemcp https://daisyui.com --concurrency 10
-
-# or with max length
-sitemcp https://daisyui.com --max-length 3000
 ```
 
 ### Tool Name Strategy
 
-Use `-t, --tool-name-strategy` to specify the tool name strategy, it will be used as the MCP server name (default: `domain`):
+Use `-t, --tool-name-strategy` to specify the tool name strategy, it will be used as the MCP server name (default: `domain`).
 This will be used as the MCP server name.
 
 ```bash
 sitemcp https://vite.dev -t domain # indexOfVite / getDocumentOfVite
 sitemcp https://react-tweet.vercel.app/ -t subdomain # indexOfReactTweet / getDocumentOfReactTweet
 sitemcp https://ryoppippi.github.io/vite-plugin-favicons/ -t pathname # indexOfVitePluginFavicons / getDocumentOfVitePluginFavicons
+```
+
+### Max Length of Tool Name
+
+Use `-l, --max-length` to specify the max length of the tool name (default: 2000).
+Some MCP clients have a limit on the length of the tool name, so you can use this option to set a max length.
+
+```bash
+sitemcp https://vite.dev -l 10000
 ```
 
 ### Match specific pages

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ sitemcp https://daisyui.com
 
 # or better concurrency
 sitemcp https://daisyui.com --concurrency 10
+
+# or with max length
+sitemcp https://daisyui.com --max-length 3000
 ```
 
 ### Tool Name Strategy

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,10 @@ cli
 		"-t, --tool-name-strategy <strategy>",
 		"Tool name strategy ('subdomain' | 'domain' | 'pathname') default: 'domain'",
 	)
-	.option("--max-length <number>", "Maximum length of the content to return (default: 2000)") // Pff2f
+	.option(
+		"-l, --max-length <number>",
+		"Maximum length of the content to return (default: 2000)",
+	)
 	.action(async (url, flags) => {
 		if (!url) {
 			cli.outputHelp();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ cli
 		"-t, --tool-name-strategy <strategy>",
 		"Tool name strategy ('subdomain' | 'domain' | 'pathname') default: 'domain'",
 	)
+	.option("--max-length <number>", "Maximum length of the content to return (default: 2000)") // Pff2f
 	.action(async (url, flags) => {
 		if (!url) {
 			cli.outputHelp();

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,6 +24,7 @@ interface StartServerOptions {
 	cache?: boolean;
 	silent?: boolean;
 	toolNameStrategy?: ToolNameStrategy;
+	maxLength?: number;
 }
 
 export async function startServer(
@@ -37,6 +38,7 @@ export async function startServer(
 		limit,
 		cache = true,
 		toolNameStrategy = "domain",
+		maxLength = 2000,
 	} = options;
 
 	// create server instance
@@ -109,7 +111,7 @@ export async function startServer(
 		{
 			max_length: z
 				.number()
-				.default(100)
+				.default(maxLength)
 				.describe("The max length of the index to return"),
 			start_index: z
 				.number()
@@ -175,7 +177,7 @@ export async function startServer(
 			subpath: z.string().describe("The subpath of the page to return"),
 			max_length: z
 				.number()
-				.default(2000)
+				.default(maxLength)
 				.describe("The max length of the content to return"),
 			start_index: z
 				.number()


### PR DESCRIPTION
Fixes #9

Add configurable `max_length` parameter to CLI and server.

* **CLI Changes:**
  - Add `--max-length <number>` option to allow users to configure the `max_length` value.
  - Pass the `max_length` value from the CLI to the `startServer` function in the `action` method.
  - Add default value to CLI explanation for `--max-length` option.

* **Server Changes:**
  - Add `maxLength` parameter to the `StartServerOptions` interface.
  - Use the `maxLength` value from the `options` parameter in the `indexServerName` tool.
  - Use the `maxLength` value from the `options` parameter in the `getDocumentServerName` tool.

* **Documentation Changes:**
  - Update `README.md` to include the new `--max-length` option in the usage section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ryoppippi/sitemcp/pull/11?shareId=410c4a81-aa56-4756-a41a-be4b63e5623c).