### PR TITLE
feat!: replace from cleye to gunshi

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "bumpp": "^10.1.1",
         "clean-pkg-json": "^1.3.0",
         "cleye": "^1.3.4",
+        "gunshi": "^0.24.0",
         "just-pascal-case": "^3.2.0",
         "lint-staged": "^15.5.0",
         "p-queue": "^8.0.1",
@@ -248,6 +249,8 @@
 
     "args-tokenizer": ["args-tokenizer@0.3.0", "", {}, "sha512-xXAd7G2Mll5W8uo37GETpQ2VrE84M181Z7ugHFGQnJZ50M2mbOv0osSZ9VsSgPfJQ+LVG0prSi0th+ELMsno7Q=="],
 
+    "args-tokens": ["args-tokens@0.18.0", "", {}, "sha512-jL9s94QUvUBehrX+ptmkgLzvvDGcC62b6ocAv1TU3JKPBEf3OL7qUZI3r6jAI2KF9f6AOuRqwP3+CZBpZBTblA=="],
+
     "body-parser": ["body-parser@2.2.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.0", "http-errors": "^2.0.0", "iconv-lite": "^0.6.3", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.0", "type-is": "^2.0.0" } }, "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
@@ -395,6 +398,8 @@
     "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "gunshi": ["gunshi@0.24.0", "", { "dependencies": { "args-tokens": "^0.18.0" } }, "sha512-gghYZ1HbTNbId4Uv5GeLtajMPI4DQPQBjjdBzEy7AIvBmQJqnxgKB0CGJXXCcgdKle+JnLH9deqTEz0o17+6sw=="],
 
     "happy-dom": ["happy-dom@16.8.1", "", { "dependencies": { "webidl-conversions": "^7.0.0", "whatwg-mimetype": "^3.0.0" } }, "sha512-n0QrmT9lD81rbpKsyhnlz3DgnMZlaOkJPpgi746doA+HvaMC79bdWkwjrNnGJRvDrWTI8iOcJiVTJ5CdT/AZRw=="],
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 		"bumpp": "^10.1.1",
 		"clean-pkg-json": "^1.3.0",
 		"cleye": "^1.3.4",
+		"gunshi": "^0.24.0",
 		"just-pascal-case": "^3.2.0",
 		"lint-staged": "^15.5.0",
 		"p-queue": "^8.0.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 import { cli, define } from "gunshi";
-import { version } from "../package.json";
+import { description, name, version } from "../package.json";
 import { startServer } from "./server.ts";
 import { TOOL_NAME_STRATEGIES, type ToolNameStrategy } from "./types.ts";
 
@@ -110,7 +110,7 @@ $ sitemcp https://ryoppippi.com --no-cache`,
 });
 
 await cli(process.argv.slice(2), command, {
-	name: "sitemcp",
+	name,
 	version,
-	description: "Site MCP - Convert websites to MCP tools",
+	description,
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,88 +1,115 @@
-import { cli } from "cleye";
+import { cli, define } from "gunshi";
 import { version } from "../package.json";
 import { startServer } from "./server.ts";
 import { TOOL_NAME_STRATEGIES, type ToolNameStrategy } from "./types.ts";
 
-const argv = cli({
+const command = define({
 	name: "sitemcp",
-	version,
-	parameters: [
-		"<url>", // The URL to fetch
-	],
-	flags: {
+	description: "Site MCP - Convert websites to MCP tools",
+
+	args: {
+		url: {
+			type: "positional",
+			description: "The URL to fetch",
+		},
 		concurrency: {
-			type: Number,
+			type: "number",
+			short: "c",
 			default: 3,
-			alias: "c",
 			description: "Number of concurrent requests",
 		},
 		match: {
-			type: [String],
-			placeholder: "<pattern>",
-			alias: "m",
+			type: "string",
+			multiple: true,
+			short: "m",
 			description: "Only fetch matched pages",
 		},
 		contentSelector: {
-			type: String,
-			placeholder: "<selector>",
+			type: "string",
 			description: "The CSS selector to find content",
 		},
 		limit: {
-			type: Number,
+			type: "number",
 			description: "Limit the result to this amount of pages",
 		},
-		noCache: {
-			type: Boolean,
-			default: false,
+		cache: {
+			type: "boolean",
+			negatable: true,
 			description: "Disable cache",
+			default: true,
 		},
 		toolNameStrategy: {
-			type: (type: ToolNameStrategy): ToolNameStrategy => {
-				if (!TOOL_NAME_STRATEGIES.includes(type)) {
-					throw new Error(`Invalid tool name strategy: ${type}`);
-				}
-				return type;
-			},
-			placeholder: "<strategy>",
-			default: "domain" as const,
-			alias: "t",
-			description: `Tool name strategy (${TOOL_NAME_STRATEGIES.join(", ")})`,
+			type: "enum",
+			short: "t",
+			default: "domain",
+			choices: TOOL_NAME_STRATEGIES,
+			description: "Tool name strategy",
 		},
 		maxLength: {
-			type: Number,
+			type: "number",
+			short: "l",
 			default: 2000,
-			alias: "l",
 			description: "Maximum length of the content to return",
 		},
 	},
-	help: {
-		examples: [
-			"# Basic usage",
-			"$ sitemcp https://example.com",
-			"",
-			"# With better concurrency",
-			"$ sitemcp https://daisyui.com --concurrency 10",
-			"",
-			"# With a custom tool name strategy",
-			"$ sitemcp https://react-tweet.vercel.app/ -t subdomain # tool names would be indexOfReactTweet / getDocumentOfReactTweet",
-			"",
-			"# With matching specific pages",
-			'$ sitemcp https://vite.dev -m "/blog/**" -m "/guide/**"',
-			"",
-			"# With a custom content selector",
-			'$ sitemcp https://vite.dev --content-selector ".content"',
-			"",
-			"# With a custom content length",
-			"$ sitemcp https://vite.dev -l 10000",
-			"",
-			"# Without cache",
-			"$ sitemcp https://ryoppippi.com --no-cache",
-		],
+
+	examples: `# Basic usage
+$ sitemcp https://example.com
+
+# With better concurrency
+$ sitemcp https://daisyui.com --concurrency 10
+
+# With a custom tool name strategy
+$ sitemcp https://react-tweet.vercel.app/ -t subdomain # tool names would be indexOfReactTweet / getDocumentOfReactTweet
+
+# With matching specific pages
+$ sitemcp https://vite.dev -m "/blog/**" -m "/guide/**"
+
+# With a custom content selector
+$ sitemcp https://vite.dev --content-selector ".content"
+
+# With a custom content length
+$ sitemcp https://vite.dev -l 10000
+
+# Without cache
+$ sitemcp https://ryoppippi.com --no-cache`,
+
+	run: async (ctx) => {
+		const {
+			url,
+			concurrency,
+			match,
+			contentSelector,
+			limit,
+			cache,
+			toolNameStrategy,
+			maxLength,
+		} = ctx.values;
+
+		// Validate toolNameStrategy
+		if (
+			toolNameStrategy &&
+			!TOOL_NAME_STRATEGIES.includes(toolNameStrategy as ToolNameStrategy)
+		) {
+			throw new Error(`Invalid tool name strategy: ${toolNameStrategy}`);
+		}
+
+		// Validate required positional argument
+		if (!url) {
+			throw new Error("URL is required");
+		}
+
+		await startServer({
+			concurrency: concurrency ?? 3,
+			match: match ?? [],
+			contentSelector,
+			limit,
+			cache,
+			toolNameStrategy: (toolNameStrategy as ToolNameStrategy) ?? "domain",
+			maxLength: maxLength ?? 2000,
+			url,
+		});
 	},
 });
 
-await startServer({
-	...argv.flags,
-	cache: !argv.flags.noCache,
-	url: argv._.url,
-});
+await cli(process.argv.slice(2), command);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,9 +4,6 @@ import { startServer } from "./server.ts";
 import { TOOL_NAME_STRATEGIES, type ToolNameStrategy } from "./types.ts";
 
 const command = define({
-	name: "sitemcp",
-	description: "Site MCP - Convert websites to MCP tools",
-
 	args: {
 		url: {
 			type: "positional",
@@ -112,4 +109,8 @@ $ sitemcp https://ryoppippi.com --no-cache`,
 	},
 });
 
-await cli(process.argv.slice(2), command);
+await cli(process.argv.slice(2), command, {
+	name: "sitemcp",
+	version,
+	description: "Site MCP - Convert websites to MCP tools",
+});


### PR DESCRIPTION
Migrate from cleye to gunshi.

This code is partially written by human and almost written by Sonnet4.
To refactor this, I used
- SiteMCP - fetch docs from https://gunshi.dev
- Claude Desktop 
- Sonnet 4


![SCR-20250523-lnfl](https://github.com/user-attachments/assets/e90bcbc2-8d37-4db1-a365-955b02f4d1e9)

This pull request introduces significant updates to the project, including rebranding, configuration enhancements, and workflow automation. The project has been renamed from `sitefetch` to `sitemcp`, with new features, dependencies, and workflows added to support its functionality as an MCP server. Below are the most important changes grouped by theme:

### Rebranding and Feature Enhancements:
* Renamed the project from `sitefetch` to `sitemcp`, updated the `README.md` with new usage instructions, added badges, and introduced new features like tool name strategies and content length customization. (`README.md`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R76) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L48-R132)
* Updated `package.json` to reflect the new name (`sitemcp`), added MCP-related dependencies like `@modelcontextprotocol/sdk`, and replaced the build system with `tsdown`. (`package.json`, [package.jsonL2-R61](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R61))
* Replaced the CLI implementation with `gunshi`, introducing a more structured command definition and support for additional options like `--tool-name-strategy` and `--max-length`. (`src/cli.ts`, [src/cli.tsL1-R115](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddL1-R115))

### Configuration and Workflow Automation:
* Added a `biome.json` configuration file for linting, formatting, and organizing imports, with rules for suspicious code and style preferences. (`biome.json`, [biome.jsonR1-R42](diffhunk://#diff-2bc8a1f5e9380d5a187a4e90f11b4dd36c3abad6aea44c84be354a4f44cdec55R1-R42))
* Introduced GitHub Actions workflows for CI (`ci.yaml`) and release automation (`release.yaml`), including steps for linting, type-checking, testing, and publishing. (`ci.yaml`, [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR1-R40); `release.yaml`, [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR1-R46)
* Added a Renovate configuration (`renovate.json`) to manage dependency updates, including custom package rules and schedules. (`renovate.json`, [.github/renovate.jsonR1-R30](diffhunk://#diff-f82f7d36a61d22f640c25bdb8b0435bf9cb38679d99d5f460753fa668ee7cdb3R1-R30))

### Licensing and Ownership:
* Updated the `LICENSE` file to reflect the new author, `ryoppippi`. (`LICENSE`, [LICENSEL3-R3](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3))
* Added a funding configuration to `.github/FUNDING.yaml` to enable GitHub Sponsors. (`FUNDING.yaml`, [.github/FUNDING.yamlR1](diffhunk://#diff-838dac57fc5a48615dad4f1ff8b2876184bcd82392fe2c264a4a2636f61b75faR1))

### Cleanup and Deprecation:
* Removed the `rolldown` build configuration and replaced it with `tsdown` in the build process. (`rolldown.config.js`, [rolldown.config.jsL1-L50](diffhunk://#diff-8855770c4f66e227cf3702458f6cc95367de11bebf47ca452cb4a8deffede1e5L1-L50))
* Deleted the `.prettierrc` file, likely replaced by the formatting rules in `biome.json`. (`.prettierrc`, [.prettierrcL1-L3](diffhunk://#diff-663ade211b3a1552162de21c4031fcd16be99407aae5ceecbb491a2efc43d5d2L1-L3))

### Registry and Publishing:
* Added an `.npmrc` file to configure the package registry for `@jsr`. (`.npmrc`, [.npmrcR1](diffhunk://#diff-e813096d69c49812e40e00be9ac8fa14d77f0ec1f97ab4c45cb096b3bedd35deR1))

These changes collectively modernize the project, align it with the new branding, and improve its maintainability and automation.