### PR TITLE
Refactor: Rewrite CLI parser from gunshi to commander

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@mozilla/readability": "^0.5.0",
         "cheerio": "^1.0.0",
+        "commander": "^14.0.0",
         "happy-dom": "^16.5.3",
         "micromatch": "^4.0.8",
         "turndown": "^7.2.0",
@@ -304,7 +305,7 @@
 
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
-    "commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
+    "commander": ["commander@14.0.0", "", {}, "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA=="],
 
     "confbox": ["confbox@0.2.2", "", {}, "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ=="],
 
@@ -677,6 +678,8 @@
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "happy-dom/whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
+    "lint-staged/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
 
     "lint-staged/yaml": ["yaml@2.7.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ=="],
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
 		"micromatch": "^4.0.8",
 		"turndown": "^7.2.0",
 		"turndown-plugin-gfm": "^1.0.2",
-		"zod": "^3.24.2"
+		"zod": "^3.24.2",
+		"commander": "^14.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,116 +1,112 @@
-import { cli, define } from "gunshi";
+import { Command, Option } from "commander";
 import { description, name, version } from "../package.json";
 import { startServer } from "./server.ts";
 import { TOOL_NAME_STRATEGIES, type ToolNameStrategy } from "./types.ts";
 
-const command = define({
-	args: {
-		url: {
-			type: "positional",
-			description: "The URL to fetch",
+const program = new Command();
+
+program
+	.name(name)
+	.description(description)
+	.version(version)
+	.argument("<url>", "The URL to fetch")
+	.option(
+		"-c, --concurrency <number>",
+		"Number of concurrent requests",
+		"3",
+	)
+	.option("-m, --match <value...>", "Only fetch matched pages")
+	.option(
+		"--content-selector <string>",
+		"The CSS selector to find content",
+	)
+	.option("--limit <number>", "Limit the result to this amount of pages")
+	.option('--no-cache', 'Disable cache (default: cache is enabled)')
+	// .option(
+	// 	"-t, --tool-name-strategy <value>",
+	// 	"Tool name strategy",
+	// 	"domain",
+	// ).choices(['domain', 'fqdn', 'subdomain']) // Using TOOL_NAME_STRATEGIES in the new way
+	.option(
+		"-l, --max-length <number>",
+		"Maximum length of the content to return",
+		"2000",
+	);
+
+const toolNameStrategyOption = new Option('-t, --tool-name-strategy <value>', 'Tool name strategy')
+  .default('domain')
+  .choices(TOOL_NAME_STRATEGIES);
+program.addOption(toolNameStrategyOption);
+
+program.addHelpText(
+		"after",
+		`
+Examples:
+  # Basic usage
+  $ sitemcp https://example.com
+
+  # With better concurrency
+  $ sitemcp https://daisyui.com --concurrency 10
+
+  # With a custom tool name strategy
+  $ sitemcp https://react-tweet.vercel.app/ -t subdomain # tool names would be indexOfReactTweet / getDocumentOfReactTweet
+
+  # With matching specific pages
+  $ sitemcp https://vite.dev -m "/blog/**" -m "/guide/**"
+
+  # With a custom content selector
+  $ sitemcp https://vite.dev --content-selector ".content"
+
+  # With a custom content length
+  $ sitemcp https://vite.dev -l 10000
+
+  # Without cache
+  $ sitemcp https://ryoppippi.com --no-cache`,
+	)
+	.action(
+		async (
+			url: string,
+			options: {
+				concurrency: string;
+				match?: string[];
+				contentSelector?: string;
+				limit?: string;
+				cache?: boolean; // Changed from noCache to cache, as per Commander's --no-flag behavior
+				toolNameStrategy: string;
+				maxLength: string;
+			},
+		) => {
+			const {
+				concurrency,
+				match,
+				contentSelector,
+				limit,
+				cache, // Changed from noCache to cache
+				toolNameStrategy,
+				maxLength,
+			} = options;
+
+			// Validate toolNameStrategy
+			if (
+				toolNameStrategy &&
+				!TOOL_NAME_STRATEGIES.includes(toolNameStrategy as ToolNameStrategy)
+			) {
+				console.error(
+					`error: Option --tool-name-strategy has invalid value ${toolNameStrategy}`,
+				);
+				process.exit(1);
+			}
+			await startServer({
+				url,
+				concurrency: Number.parseInt(concurrency, 10),
+				match: match ?? [],
+				contentSelector,
+				limit: limit ? Number.parseInt(limit, 10) : undefined,
+				cache: cache, // Directly use options.cache
+				toolNameStrategy: toolNameStrategy as ToolNameStrategy,
+				maxLength: Number.parseInt(maxLength, 10),
+			});
 		},
-		concurrency: {
-			type: "number",
-			short: "c",
-			default: 3,
-			description: "Number of concurrent requests",
-		},
-		match: {
-			type: "string",
-			multiple: true,
-			short: "m",
-			description: "Only fetch matched pages",
-		},
-		"content-selector": {
-			type: "string",
-			description: "The CSS selector to find content",
-		},
-		limit: {
-			type: "number",
-			description: "Limit the result to this amount of pages",
-		},
-		cache: {
-			type: "boolean",
-			negatable: true,
-			description: "Disable cache",
-			default: true,
-		},
-		"tool-name-strategy": {
-			type: "enum",
-			short: "t",
-			default: "domain",
-			choices: TOOL_NAME_STRATEGIES,
-			description: "Tool name strategy",
-		},
-		"max-length": {
-			type: "number",
-			short: "l",
-			default: 2000,
-			description: "Maximum length of the content to return",
-		},
-	},
+	);
 
-	examples: `# Basic usage
-$ sitemcp https://example.com
-
-# With better concurrency
-$ sitemcp https://daisyui.com --concurrency 10
-
-# With a custom tool name strategy
-$ sitemcp https://react-tweet.vercel.app/ -t subdomain # tool names would be indexOfReactTweet / getDocumentOfReactTweet
-
-# With matching specific pages
-$ sitemcp https://vite.dev -m "/blog/**" -m "/guide/**"
-
-# With a custom content selector
-$ sitemcp https://vite.dev --content-selector ".content"
-
-# With a custom content length
-$ sitemcp https://vite.dev -l 10000
-
-# Without cache
-$ sitemcp https://ryoppippi.com --no-cache`,
-
-	run: async (ctx) => {
-		const {
-			url,
-			concurrency,
-			match,
-			"content-selector": contentSelector,
-			limit,
-			cache,
-			"tool-name-strategy": toolNameStrategy,
-			"max-length": maxLength,
-		} = ctx.values;
-
-		// Validate toolNameStrategy
-		if (
-			toolNameStrategy &&
-			!TOOL_NAME_STRATEGIES.includes(toolNameStrategy as ToolNameStrategy)
-		) {
-			throw new Error(`Invalid tool name strategy: ${toolNameStrategy}`);
-		}
-
-		// Validate required positional argument
-		if (!url) {
-			throw new Error("URL is required");
-		}
-
-		await startServer({
-			concurrency: concurrency ?? 3,
-			match: match ?? [],
-			contentSelector,
-			limit,
-			cache,
-			toolNameStrategy: (toolNameStrategy as ToolNameStrategy) ?? "domain",
-			maxLength: maxLength ?? 2000,
-			url,
-		});
-	},
-});
-
-await cli(process.argv.slice(2), command, {
-	name,
-	version,
-	description,
-});
+await program.parseAsync(process.argv);


### PR DESCRIPTION
Vibe coding test

Replaces the gunshi CLI parser with commander.js.

Key changes:
- All existing commands, options, and their behaviors (defaults, types, short flags, multiple values, negatable booleans, choices) have been preserved.
- The `url` argument remains positional and required.
- Options include:
    - `concurrency` (-c)
    - `match` (-m, multiple)
    - `content-selector`
    - `limit`
    - `cache` (now via `--no-cache`, defaults to true)
    - `tool-name-strategy` (-t, with choices)
    - `max-length` (-l)
- The `tool-name-strategy` option definition was updated to explicitly use `new Option().choices()` and `program.addOption()` to resolve a runtime TypeError.
- The boolean `cache` option was updated to use the `--no-cache` pattern, correctly defaulting to `true` and setting to `false` when `--no-cache` is specified.
- CLI examples in the help output have been preserved.

The CLI now uses commander for a more robust and widely-used argument parsing solution.