### PR TITLE
feat: Add sitemap.xml support for efficient site discovery

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@mozilla/readability": "^0.5.0",
+        "birpc": "^2.5.0",
         "cheerio": "^1.0.0",
         "happy-dom": "^16.5.3",
         "micromatch": "^4.0.8",
@@ -176,7 +177,7 @@
 
     "ast-kit": ["ast-kit@2.1.0", "", { "dependencies": { "@babel/parser": "^7.27.3", "pathe": "^2.0.3" } }, "sha512-ROM2LlXbZBZVk97crfw8PGDOBzzsJvN2uJCmwswvPUNyfH14eg90mSN3xNqsri1JS1G9cz0VzeDUhxJkTrr4Ew=="],
 
-    "birpc": ["birpc@2.4.0", "", {}, "sha512-5IdNxTyhXHv2UlgnPHQ0h+5ypVmkrYHzL8QT+DwFZ//2N/oNV8Ch+BCRmTJ3x6/z9Axo/cXYBc9eprsUVK/Jsg=="],
+    "birpc": ["birpc@2.5.0", "", {}, "sha512-VSWO/W6nNQdyP520F1mhf+Lc2f8pjGQOtoHHm7Ze8Go1kX7akpVIrtTa0fn+HB0QJEDVacl6aO08YE0PgXfdnQ=="],
 
     "body-parser": ["body-parser@2.2.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.0", "http-errors": "^2.0.0", "iconv-lite": "^0.6.3", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.0", "type-is": "^2.0.0" } }, "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg=="],
 
@@ -595,6 +596,8 @@
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "rolldown/ansis": ["ansis@4.1.0", "", {}, "sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w=="],
+
+    "rolldown-plugin-dts/birpc": ["birpc@2.4.0", "", {}, "sha512-5IdNxTyhXHv2UlgnPHQ0h+5ypVmkrYHzL8QT+DwFZ//2N/oNV8Ch+BCRmTJ3x6/z9Axo/cXYBc9eprsUVK/Jsg=="],
 
     "rolldown-plugin-dts/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.9.0",
 		"@mozilla/readability": "^0.5.0",
+		"birpc": "^2.5.0",
 		"cheerio": "^1.0.0",
 		"happy-dom": "^16.5.3",
 		"micromatch": "^4.0.8",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,8 +60,8 @@ const command = define({
 		},
 		timeout: {
 			type: "number",
-			description: "Timeout in seconds for site fetching (default: 300)",
-			default: 300,
+			description: "Timeout in seconds for site fetching (default: 60)",
+			default: 60,
 		},
 	},
 
@@ -130,7 +130,7 @@ $ sitemcp https://example.com --sitemap-url /custom-sitemap.xml`,
 			maxLength: maxLength ?? 2000,
 			url,
 			sitemap: sitemapUrl || sitemap,
-			timeout: timeout ?? 300,
+			timeout: timeout ?? 25,
 		});
 	},
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,6 +49,20 @@ const command = define({
 			default: 2000,
 			description: "Maximum length of the content to return",
 		},
+		sitemap: {
+			type: "boolean",
+			short: "s",
+			description: "Use sitemap.xml to discover URLs (auto-detect)",
+		},
+		sitemapUrl: {
+			type: "string",
+			description: "Custom sitemap URL path",
+		},
+		timeout: {
+			type: "number",
+			description: "Timeout in seconds for site fetching (default: 300)",
+			default: 300,
+		},
 	},
 
 	examples: `# Basic usage
@@ -70,7 +84,13 @@ $ sitemcp https://vite.dev --content-selector ".content"
 $ sitemcp https://vite.dev -l 10000
 
 # Without cache
-$ sitemcp https://ryoppippi.com --no-cache`,
+$ sitemcp https://ryoppippi.com --no-cache
+
+# With sitemap auto-detection
+$ sitemcp https://nextjs.org --sitemap
+
+# With custom sitemap URL
+$ sitemcp https://example.com --sitemap-url /custom-sitemap.xml`,
 
 	run: async (ctx) => {
 		const {
@@ -82,6 +102,9 @@ $ sitemcp https://ryoppippi.com --no-cache`,
 			cache,
 			toolNameStrategy,
 			maxLength,
+			sitemap,
+			sitemapUrl,
+			timeout,
 		} = ctx.values;
 
 		// Validate toolNameStrategy
@@ -106,6 +129,8 @@ $ sitemcp https://ryoppippi.com --no-cache`,
 			toolNameStrategy: (toolNameStrategy as ToolNameStrategy) ?? "domain",
 			maxLength: maxLength ?? 2000,
 			url,
+			sitemap: sitemapUrl || sitemap,
+			timeout: timeout ?? 300,
 		});
 	},
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -129,7 +129,7 @@ $ sitemcp https://example.com --sitemap-url /custom-sitemap.xml`,
 			toolNameStrategy: (toolNameStrategy as ToolNameStrategy) ?? "domain",
 			maxLength: maxLength ?? 2000,
 			url,
-			sitemap: sitemapUrl || sitemap,
+			sitemap: sitemapUrl !== undefined ? sitemapUrl : sitemap,
 			timeout: timeout ?? 25,
 		});
 	},

--- a/src/fetch-site.ts
+++ b/src/fetch-site.ts
@@ -282,7 +282,7 @@ class Fetcher {
 		const controller = new AbortController();
 		const remainingTime = Math.max(
 			5000,
-			this.#globalTimeoutMs - (Date.now() - this.#startTime),
+			Math.max(0, this.#globalTimeoutMs - (Date.now() - this.#startTime)),
 		);
 		const pageTimeout = Math.min(15000, remainingTime); // Max 15 seconds per page
 		const timeoutId = setTimeout(() => controller.abort(), pageTimeout);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,11 +1,11 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { Worker } from "node:worker_threads";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { stringify } from "@std/yaml";
 import { z } from "zod";
 import { version } from "../package.json";
-import { fetchSite } from "./fetch-site.ts";
 import { logger } from "./logger.ts";
 import type { FetchSiteResult, StartServerOptions } from "./types.ts";
 import {
@@ -44,71 +44,132 @@ export async function startServer(
 	const catchDir = cacheDirectory();
 	const cacheFile = path.join(catchDir, `${sanitisedUrl}.json`);
 
-	let pages: FetchSiteResult | undefined = undefined;
+	let pages: FetchSiteResult = new Map();
+	let isFetching = false;
+	let fetchingPromise: Promise<void> | null = null;
+	let worker: Worker | null = null;
 
-	if (cache) {
-		// check if cache exists
-		if (fs.existsSync(cacheFile)) {
-			logger.info("Using cache file", cacheFile);
-			const json = fs.readFileSync(cacheFile, "utf-8");
-			try {
-				pages = new Map(Object.entries(JSON.parse(json)));
-			} catch (e) {
-				logger.warn("Cache file is invalid, ignoring");
-				pages = undefined;
-			}
-		}
-	}
-
-	if (pages == null) {
-		// Add timeout to prevent hanging during site fetching
-		const timeoutMs = (timeout ?? 300) * 1000; // Convert seconds to milliseconds
-		const timeoutPromise = new Promise<never>((_, reject) => {
-			setTimeout(
-				() =>
-					reject(
-						new Error(
-							`Site fetching timed out after ${timeout ?? 300} seconds`,
-						),
-					),
-				timeoutMs,
-			);
-		});
-
+	// Load from cache if available
+	if (cache && fs.existsSync(cacheFile)) {
+		logger.info("Using cache file", cacheFile);
+		const json = fs.readFileSync(cacheFile, "utf-8");
 		try {
-			pages = await Promise.race([
-				fetchSite(url, {
-					concurrency,
-					match: (match && ensureArray(match)) as string[],
-					contentSelector,
-					limit,
-					sitemap,
-				}),
-				timeoutPromise,
-			]);
-		} catch (error) {
-			logger.warn(
-				`Site fetching failed: ${error instanceof Error ? error.message : "Unknown error"}`,
-			);
-			pages = new Map(); // Continue with empty pages to allow server to start
+			pages = new Map(Object.entries(JSON.parse(json)));
+			logger.info(`Loaded ${pages.size} pages from cache`);
+		} catch (e) {
+			logger.warn("Cache file is invalid, ignoring");
+			pages = new Map();
 		}
 	}
 
-	if (pages.size === 0) {
-		logger.warn("No pages found");
-		return server;
-	}
+	// Start background fetching (don't wait for completion)
+	const startBackgroundFetching = async () => {
+		if (isFetching) return fetchingPromise;
 
-	if (cache) {
-		// create cache dir if not exists
-		if (!fs.existsSync(catchDir)) {
-			fs.promises.mkdir(catchDir, { recursive: true });
-		}
-		// write to cache file
-		const json = JSON.stringify(Object.fromEntries(pages), null, 2);
-		await fs.promises.writeFile(cacheFile, json, "utf-8");
-		logger.info("Cache file written to", cacheFile);
-	}
+		isFetching = true;
+		fetchingPromise = (async () => {
+			try {
+				const timeoutMs = (timeout ?? 60) * 1000;
+
+				// Create worker for background fetching
+				const isDev = import.meta.dirname.includes("src");
+				const workerFile = isDev ? "worker.ts" : "worker.mjs";
+				const workerPath = path.join(import.meta.dirname, workerFile);
+				worker = new Worker(workerPath);
+
+				const workerPromise = new Promise<FetchSiteResult>(
+					(resolve, reject) => {
+						worker?.on("message", (message) => {
+							switch (message.type) {
+								case "complete":
+									resolve(new Map(message.data));
+									break;
+								case "error":
+									reject(new Error(message.error));
+									break;
+								case "progress":
+									// Handle progress updates if needed
+									break;
+							}
+						});
+
+						worker?.on("error", reject);
+						worker?.on("exit", (code) => {
+							if (code !== 0) {
+								reject(new Error(`Worker stopped with exit code ${code}`));
+							}
+						});
+					},
+				);
+
+				const timeoutPromise = new Promise<never>((_, reject) => {
+					setTimeout(() => {
+						worker?.terminate();
+						reject(
+							new Error(
+								`Site fetching timed out after ${timeout ?? 60} seconds`,
+							),
+						);
+					}, timeoutMs);
+				});
+
+				// Start worker
+				worker.postMessage({
+					type: "start",
+					url,
+					options: {
+						concurrency,
+						match: (match && ensureArray(match)) as string[],
+						contentSelector,
+						limit,
+						sitemap,
+						timeout,
+					},
+				});
+
+				const freshPages = await Promise.race([workerPromise, timeoutPromise]);
+
+				// Merge fresh pages with existing pages
+				for (const [key, value] of freshPages) {
+					pages.set(key, value);
+				}
+
+				if (cache) {
+					// create cache dir if not exists
+					if (!fs.existsSync(catchDir)) {
+						await fs.promises.mkdir(catchDir, { recursive: true });
+					}
+					// write to cache file
+					const json = JSON.stringify(Object.fromEntries(pages), null, 2);
+					await fs.promises.writeFile(cacheFile, json, "utf-8");
+					logger.info("Cache file written to", cacheFile);
+				}
+
+				logger.info(
+					`Background fetching completed. Total pages: ${pages.size}`,
+				);
+			} catch (error) {
+				logger.warn(
+					`Background site fetching failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+				);
+			} finally {
+				// Clean up worker
+				if (worker) {
+					worker.terminate();
+					worker = null;
+				}
+				isFetching = false;
+				fetchingPromise = null;
+			}
+		})();
+
+		return fetchingPromise;
+	};
+
+	// Start background fetching but don't wait for it
+	startBackgroundFetching().catch(() => {
+		// Error already logged in startBackgroundFetching
+	});
 
 	const indexServerName =
 		`indexOf${sanitiseToolName(url, toolNameStrategy)}` as const;
@@ -152,13 +213,22 @@ export async function startServer(
 				index = newIndex;
 			}
 
+			const status = isFetching ? "fetching" : "ready";
+
 			if (index.length === 0) {
-				logger.warn("No pages found");
+				const message = isFetching
+					? "Site is being fetched in the background. Please try again in a moment."
+					: "No pages found";
+				logger.warn(message);
 				return {
 					content: [
 						{
 							type: "text",
-							text: "No pages found",
+							text: stringify({
+								status,
+								message,
+								totalPages: pages.size,
+							}),
 						},
 					],
 				};
@@ -169,9 +239,11 @@ export async function startServer(
 					{
 						type: "text",
 						text: stringify({
+							status,
 							index,
 							remainingIndexLength,
 							startIndex: start_index,
+							totalPages: pages.size,
 						}),
 					},
 				],
@@ -203,12 +275,32 @@ export async function startServer(
 			const page = pages.get(subpath);
 
 			if (!page) {
-				logger.warn(`Page ${subpath} not found`);
+				const status = isFetching ? "fetching" : "ready";
+				const message = isFetching
+					? `Page ${subpath} is being fetched in the background. Please try again in a moment.`
+					: `Page ${subpath} not found`;
+
+				// If we're not fetching and the page doesn't exist, trigger background fetch
+				if (!isFetching) {
+					logger.info(
+						`Triggering background fetch for missing page: ${subpath}`,
+					);
+					startBackgroundFetching().catch(() => {
+						// Error already logged in startBackgroundFetching
+					});
+				}
+
+				logger.warn(message);
 				return {
 					content: [
 						{
 							type: "text",
-							text: `Page ${subpath} not found`,
+							text: stringify({
+								status,
+								message,
+								subpath,
+								totalPages: pages.size,
+							}),
 						},
 					],
 				};

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,11 @@ export type Options = {
 	 * Timeout in seconds for site fetching
 	 */
 	timeout?: number;
+
+	/**
+	 * Abort signal for cancelling fetch operations
+	 */
+	signal?: AbortSignal;
 };
 
 export type Page = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,12 @@ export type Options = {
 	 * A custom function to fetch URL
 	 */
 	fetch?: (url: string, init: RequestInit) => Promise<Response>;
+
+	/**
+	 * Use sitemap.xml to discover URLs
+	 * Can be boolean (auto-detect) or string (custom sitemap URL)
+	 */
+	sitemap?: boolean | string;
 };
 
 export type Page = {
@@ -50,4 +56,6 @@ export interface StartServerOptions {
 	maxLength: number;
 	match?: string | string[];
 	limit?: number;
+	sitemap?: boolean | string;
+	timeout?: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,11 @@ export type Options = {
 	 * Can be boolean (auto-detect) or string (custom sitemap URL)
 	 */
 	sitemap?: boolean | string;
+
+	/**
+	 * Timeout in seconds for site fetching
+	 */
+	timeout?: number;
 };
 
 export type Page = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -119,3 +119,22 @@ export function sanitiseToolName(
 	const pascalizedName = pascalCase(name);
 	return pascalizedName;
 }
+
+/**
+ * Generate match pattern from base URL path
+ * @example
+ * - https://example.com => []
+ * - https://example.com/api/v1 => ["/api/v1/**"]
+ */
+export function generateMatchPatternFromUrl(url: string): string[] {
+	const { pathname } = new URL(url);
+
+	// If pathname is just "/" or empty, don't generate any pattern
+	if (pathname === "/" || pathname === "") {
+		return [];
+	}
+
+	// Remove trailing slash and add wildcard pattern
+	const normalizedPath = pathname.replace(/\/$/, "");
+	return [`${normalizedPath}/**`];
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,98 @@
+import { parentPort } from "node:worker_threads";
+import { fetchSite } from "./fetch-site.ts";
+import { logger } from "./logger.ts";
+import type { FetchSiteResult, Options } from "./types.ts";
+
+interface WorkerMessage {
+	type: "start" | "stop";
+	url?: string;
+	options?: Options;
+}
+
+interface WorkerResponse {
+	type: "progress" | "complete" | "error";
+	data?: Array<[string, { title: string; url: string; content: string }]>;
+	error?: string;
+}
+
+class FetchWorker {
+	private currentFetch: AbortController | null = null;
+	private isRunning = false;
+
+	async start(url: string, options: Options) {
+		if (this.isRunning) {
+			this.sendMessage({ type: "error", error: "Worker is already running" });
+			return;
+		}
+
+		this.isRunning = true;
+		this.currentFetch = new AbortController();
+
+		try {
+			logger.info(`Worker: Starting fetch for ${url}`);
+
+			// Create a promise that can be aborted
+			const fetchPromise = new Promise<FetchSiteResult>((resolve, reject) => {
+				const signal = this.currentFetch?.signal;
+
+				signal?.addEventListener("abort", () => {
+					reject(new Error("Fetch aborted"));
+				});
+
+				fetchSite(url, options).then(resolve).catch(reject);
+			});
+
+			const pages = await fetchPromise;
+
+			if (this.isRunning) {
+				this.sendMessage({
+					type: "complete",
+					data: Array.from(pages.entries()),
+				});
+			}
+		} catch (error) {
+			if (this.isRunning) {
+				const errorMessage =
+					error instanceof Error ? error.message : "Unknown error";
+				logger.warn(`Worker: Fetch failed: ${errorMessage}`);
+				this.sendMessage({
+					type: "error",
+					error: errorMessage,
+				});
+			}
+		} finally {
+			this.isRunning = false;
+			this.currentFetch = null;
+		}
+	}
+
+	stop() {
+		if (this.currentFetch) {
+			this.currentFetch.abort();
+		}
+		this.isRunning = false;
+	}
+
+	private sendMessage(message: WorkerResponse) {
+		if (parentPort) {
+			parentPort.postMessage(message);
+		}
+	}
+}
+
+const worker = new FetchWorker();
+
+if (parentPort) {
+	parentPort.on("message", (message: WorkerMessage) => {
+		switch (message.type) {
+			case "start":
+				if (message.url && message.options) {
+					worker.start(message.url, message.options);
+				}
+				break;
+			case "stop":
+				worker.stop();
+				break;
+		}
+	});
+}

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -2,7 +2,10 @@ import { defineConfig } from "tsdown";
 
 const config: ReturnType<typeof defineConfig> = defineConfig({
 	outDir: "dist",
-	entry: "src/cli.ts",
+	entry: {
+		cli: "src/cli.ts",
+		worker: "src/worker.ts",
+	},
 	fixedExtension: true,
 	publint: true,
 	dts: false,


### PR DESCRIPTION
close #19 

# Overview

This PR will add a `sitemap.xml` support for site crawling.

Some sites (like https://nextjs.org) using `sitemap.xml` so you can now use this by cli options.

```bash
# With sitemap auto-detection (using /sitemap.xml, /sitemap_index.xml, or find from /robot.txt)
$ sitemcp https://nextjs.org/docs --sitemap

# With custom sitemap URL
$ sitemcp https://nextjs.org/docs --sitemap-url /sitemap.xml
```

# Feature

## New Options

- `--sitemap`: `boolean` Use sitemap.xml to discover URLs (auto-detect)
- `--sitemap-url`: `string` Custom sitemap URL path (if this options is used, it will use sitemap regardless of that `--sitemap` is enabled)
- `--timeout`: `number` Timeout in seconds for site fetching (default: 60)

## Background Fetching using Worker Threads

After testing the core logic, I realized this MCP Server make an error in Claude Code because site fetching takes over 30s and timed out (for example, https://nextjs.org has over 300 pages). To avoid this, I implemented background processing using Worker Threads.

If you do not like it, please comment this and I will roll back soon.